### PR TITLE
修改IsAds设置逻辑

### DIFF
--- a/DYYY.xm
+++ b/DYYY.xm
@@ -833,7 +833,7 @@ void downloadAllImages(NSMutableArray *imageURLs) {
 
 - (void)setIsAds:(BOOL)isAds {
     BOOL noAds = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYNoAds"];
-    %orig(noAds ? NO : isAds); 
+    %orig(noAds ? isAds : NO);
 }
 
 %end


### PR DESCRIPTION
如果noads为真不修改广告标识，如果为假则设置广告标识为NO，便于部分视频倍速播放